### PR TITLE
Support custom query to send incremental updates.

### DIFF
--- a/adaptor-config.properties.sample
+++ b/adaptor-config.properties.sample
@@ -54,21 +54,6 @@ documentum.src =
 # are pushed to GSA.
 # documentum.pushLocalGroupsOnly = false
 
-# Custom query to send modified documents. Incremental updates uses this query
-# to find the modified documents and send to GSA. {0} will be replaced by the
-# modified date and {1} will be replaced by the object ID. The select list
-# needs to include r_modify_date_str, r_object_id, i_chronicle_id
-# and object_name.
-# documentum.updatedDocumentsQuery = SELECT r_modify_date, r_object_id, \
-#     i_chronicle_id, object_name, DATETOSTRING_LOCAL(r_modify_date, \
-#     ‘yyyy-mm-dd hh:mi:ss') AS r_modify_date_str \
-#     FROM dm_sysobject WHERE (TYPE(dm_document) OR TYPE(dm_folder)) \
-#     AND ((r_modify_date = DATE(‘’{0}’’,''yyyy-mm-dd hh:mi:ss'') \
-#     AND r_object_id > ‘’{1}’’) OR (r_modify_date > DATE(''{0}'', \
-#     ‘’yyyy-mm-dd hh:mi:ss''))) AND (FOLDER(‘/Repository’,descend)) \
-#     ORDER BY r_modify_date, r_object_id
-
-
 # The where clause matching all the cabinets to be indexed when the
 # documentum.src value contains the start path "/".
 # documentum.cabinetWhereCondition = object_name NOT IN ('Integration', \
@@ -97,3 +82,19 @@ documentum.src =
 #     r_link_cnt, r_link_high_cnt, r_lock_date, r_lock_machine, r_lock_owner, \
 #     r_modifier, r_order_no, r_page_cnt, r_policy_id, r_resume_state, \
 #     r_version_label, resolution_label, world_permit
+
+# Custom query to send modified documents. Incremental updates uses this query
+# to find the modified documents and send to GSA. {0} will be replaced by the
+# modified date and {1} will be replaced by the object ID. The select list
+# needs to include r_modify_date_str, r_object_id, i_chronicle_id
+# and object_name. It also need to order by modify time and object ID.
+# “dm_document” in this example is documentum.documentTypes property value
+# and “/Repository” is documentum.src property value.
+# documentum.modifiedDocumentsQuery = SELECT r_modify_date, r_object_id, \
+#     i_chronicle_id, object_name, DATETOSTRING_LOCAL(r_modify_date, \
+#     ''yyyy-mm-dd hh:mi:ss'') AS r_modify_date_str \
+#     FROM dm_sysobject WHERE (TYPE(dm_document) OR TYPE(dm_folder)) \
+#     AND ((r_modify_date = DATE(''{0}'',''yyyy-mm-dd hh:mi:ss'') \
+#     AND r_object_id > ''{1}'') OR (r_modify_date > DATE(''{0}'', \
+#     ''yyyy-mm-dd hh:mi:ss''))) AND (FOLDER(''/Repository'',descend)) \
+#     ORDER BY r_modify_date, r_object_id

--- a/adaptor-config.properties.sample
+++ b/adaptor-config.properties.sample
@@ -54,6 +54,21 @@ documentum.src =
 # are pushed to GSA.
 # documentum.pushLocalGroupsOnly = false
 
+# Custom query to send modified documents. Incremental updates uses this query
+# to find the modified documents and send to GSA. {0} will be replaced by the
+# modified date and {1} will be replaced by the object ID. The select list
+# needs to include r_modify_date_str, r_object_id, i_chronicle_id
+# and object_name.
+# documentum.updatedDocumentsQuery = SELECT r_modify_date, r_object_id, \
+#     i_chronicle_id, object_name, DATETOSTRING_LOCAL(r_modify_date, \
+#     ‘yyyy-mm-dd hh:mi:ss') AS r_modify_date_str \
+#     FROM dm_sysobject WHERE (TYPE(dm_document) OR TYPE(dm_folder)) \
+#     AND ((r_modify_date = DATE(‘’{0}’’,''yyyy-mm-dd hh:mi:ss'') \
+#     AND r_object_id > ‘’{1}’’) OR (r_modify_date > DATE(''{0}'', \
+#     ‘’yyyy-mm-dd hh:mi:ss''))) AND (FOLDER(‘/Repository’,descend)) \
+#     ORDER BY r_modify_date, r_object_id
+
+
 # The where clause matching all the cabinets to be indexed when the
 # documentum.src value contains the start path "/".
 # documentum.cabinetWhereCondition = object_name NOT IN ('Integration', \

--- a/src/com/google/enterprise/adaptor/documentum/DocumentumAdaptor.java
+++ b/src/com/google/enterprise/adaptor/documentum/DocumentumAdaptor.java
@@ -599,15 +599,19 @@ public class DocumentumAdaptor extends AbstractAdaptor implements
   private void validateModifiedDocumentsQuery(IDfSession session)
       throws DfException {
     Checkpoint checkpoint = Checkpoint.incremental();
-    String queryStr = MessageFormat.format(modifiedDocumentsQuery,
-        checkpoint.getLastModified(), checkpoint.getObjectId());
-
-    IDfQuery query = dmClientX.getQuery();
-    query.setDQL(queryStr);
     IDfCollection result = null;
     try {
+      String queryStr = MessageFormat.format(modifiedDocumentsQuery,
+          checkpoint.getLastModified(), checkpoint.getObjectId());
+      IDfQuery query = dmClientX.getQuery();
+      query.setDQL(queryStr);
       result = query.execute(session, IDfQuery.DF_EXECREAD_QUERY);
-      result.next();
+      if (result.next()) {
+        result.getString("r_modify_date_str");
+        result.getString("r_object_id");
+        result.getString("i_chronicle_id");
+        result.getString("object_name");
+      }
     } catch (DfException | IllegalArgumentException e) {
       logger.log(Level.WARNING,
           "Error validating modified documents query {0}: {1}",

--- a/src/com/google/enterprise/adaptor/documentum/DocumentumAdaptor.java
+++ b/src/com/google/enterprise/adaptor/documentum/DocumentumAdaptor.java
@@ -70,7 +70,6 @@ import java.text.MessageFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -609,11 +608,11 @@ public class DocumentumAdaptor extends AbstractAdaptor implements
     try {
       result = query.execute(session, IDfQuery.DF_EXECREAD_QUERY);
       result.next();
-    } catch (DfException e) {
+    } catch (DfException | IllegalArgumentException e) {
       logger.log(Level.WARNING,
           "Error validating modified documents query {0}: {1}",
           new Object[] {modifiedDocumentsQuery, e});
-      // set to empty so that default query would be used.
+      // set to empty so that default query will be used.
       modifiedDocumentsQuery = "";
     } finally {
       if (result != null) {

--- a/src/com/google/enterprise/adaptor/documentum/DocumentumAdaptor.java
+++ b/src/com/google/enterprise/adaptor/documentum/DocumentumAdaptor.java
@@ -438,7 +438,8 @@ public class DocumentumAdaptor extends AbstractAdaptor implements
     logger.log(Level.CONFIG, "documentum.queryBatchSize: {0}", queryBatchSize);
     maxHtmlSize = getPositiveInt(config, "documentum.maxHtmlSize");
     logger.log(Level.CONFIG, "documentum.maxHtmlSize: {0}", maxHtmlSize);
-    modifiedDocumentsQuery = config.getValue("documentum.modifiedDocumentsQuery");
+    modifiedDocumentsQuery =
+        config.getValue("documentum.modifiedDocumentsQuery");
     logger.log(Level.CONFIG, "documentum.modifiedDocumentsQuery: {0}",
         modifiedDocumentsQuery);
     cabinetWhereCondition =
@@ -598,9 +599,9 @@ public class DocumentumAdaptor extends AbstractAdaptor implements
 
   private void validateModifiedDocumentsQuery(IDfSession session)
       throws DfException {
-    Checkpoint checkpoint = Checkpoint.incremental();
     IDfCollection result = null;
     try {
+      Checkpoint checkpoint = Checkpoint.incremental();
       String queryStr = MessageFormat.format(modifiedDocumentsQuery,
           checkpoint.getLastModified(), checkpoint.getObjectId());
       IDfQuery query = dmClientX.getQuery();

--- a/test/com/google/enterprise/adaptor/documentum/DocumentumAdaptorTest.java
+++ b/test/com/google/enterprise/adaptor/documentum/DocumentumAdaptorTest.java
@@ -5122,8 +5122,8 @@ public class DocumentumAdaptorTest {
       Checkpoint checkpoint, List<Record> expectedRecords,
       Checkpoint expectedCheckpoint)
       throws DfException, IOException, InterruptedException {
-    checkModifiedDocIdsPushed(ImmutableMap.of(), startPaths, checkpoint,
-        expectedRecords, expectedCheckpoint);
+    checkModifiedDocIdsPushed(ImmutableMap.<String, String>of(), startPaths,
+        checkpoint, expectedRecords, expectedCheckpoint);
   }
 
   private void checkModifiedDocIdsPushed(Map<String, ?> configMap,

--- a/test/com/google/enterprise/adaptor/documentum/DocumentumAdaptorTest.java
+++ b/test/com/google/enterprise/adaptor/documentum/DocumentumAdaptorTest.java
@@ -5239,13 +5239,6 @@ public class DocumentumAdaptorTest {
     insertDocument(MAR_1970, DOCUMENT.pad("bbb"), folder + "/bbb", folderId);
 
     checkModifiedDocIdsPushed(
-        ImmutableMap.of(),
-        startPaths(folder),
-        new Checkpoint(FEB_1970, DOCUMENT.pad("aaa")),
-        makeExpectedDocIds(folder, folder, "bbb"),
-        new Checkpoint(MAR_1970, DOCUMENT.pad("bbb")));
-
-    checkModifiedDocIdsPushed(
         ImmutableMap.of("documentum.modifiedDocumentsQuery", query),
         startPaths(folder),
         new Checkpoint(FEB_1970, DOCUMENT.pad("aaa")),
@@ -5275,6 +5268,12 @@ public class DocumentumAdaptorTest {
 
     testModifiedDocumentsQuery(query,
         makeExpectedDocIds(folder, "aaa", folder, "bbb"));
+  }
+
+  @Test
+  public void testModifiedDocumentsQuery_Default() throws Exception {
+    String folder = "/FFF1/FFF2";
+    testModifiedDocumentsQuery("", makeExpectedDocIds(folder, folder, "bbb"));
   }
 
   @Test


### PR DESCRIPTION
Provide config option, documentum.updatedDocumentsQuery, to specify
a custom query for sending incremental updates.