### PR TITLE
Set the dist file suffix from the auto-detected version.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -42,14 +42,6 @@
   <property name="compile.java.version" value="7"/>
   <property name="compile.java.bootclasspath" value="${build.bootclasspath}"/>
 
-  <!-- Adaptor suffix for distribution files. Useful for placing version numbers
-       on our jars. -->
-  <condition property="adaptor.suffix" value="-${adaptor.version}">
-    <isset property="adaptor.version"/>
-  </condition>
-  <!-- If adaptor.version isn't set, simply use the current date. -->
-  <property name="adaptor.suffix" value="-${DSTAMP}"/>
-
   <path id="adaptor.build.classpath">
 <!--
     <fileset dir="${lib.dir}">
@@ -165,7 +157,7 @@ lib/plexi submodule or add the the command line argument
       <arg value="--always"/>
     </exec>
     <!-- Set version if git describe failed. -->
-    <property name="adaptor.version" value="unknown"/>
+    <property name="adaptor.version" value="unknown-${DSTAMP}"/>
   </target>
 
   <target name="dist" description="Generate distribution binaries"
@@ -181,6 +173,15 @@ lib/plexi submodule or add the the command line argument
     <mkdir dir="${build.dir}/dist"/>
     <mkdir dir="${build.dir}/dist/staging"/>
     <mkdir dir="${dist.dir}"/>
+
+    <!-- Set the file name suffix from the version. Add a leading dash,
+         and strip a leading "v" prefix if it is followed by a digit. -->
+    <loadresource property="adaptor.suffix">
+      <propertyresource name="adaptor.version"/>
+      <filterchain>
+          <replaceregex pattern="^(v(?=\d))?" replace="-"/>
+      </filterchain>
+    </loadresource>
 
     <!-- Concatenate dependent JARs together into a comma-delimited list. -->
     <pathconvert pathsep=" " refid="adaptor.run.classpath"


### PR DESCRIPTION
adaptor.version is auto-detected using git, and adaptor.suffix
is set automatically from the version. Each property can be overridden
independently from the command line.

For details, see https://github.com/googlegsa/library/commit/e0163d0.